### PR TITLE
Use older version of Heroku CLI

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ source /dev/stdin <<< "$(curl -s --retry 3 https://lang-common.s3.amazonaws.com/
 BUILD_DIR=$1
 CACHE_DIR=$2
 BUILDPACK_DIR="$(dirname $(dirname "$0"))"
-HEROKU_CLI_URL="https://cli-assets.heroku.com/channels/stable/heroku-linux-x64.tar.xz"
+HEROKU_CLI_URL="https://cli-assets.heroku.com/versions/9.5.1/1aaf605/heroku-v9.5.1-1aaf605-linux-x64.tar.xz"
 
 puts_step "Fetching and vendoring Heroku CLI into slug"
 rm -rf "$BUILD_DIR/.heroku/cli"


### PR DESCRIPTION
The latest version of Heroku CLI has a problem with reading the return code properly when running `pg:copy`. https://github.com/heroku/cli/issues/3146. Support proposes using older version of CLI for now.